### PR TITLE
Fix: банковские сервисы

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <querydsl.version>5.0.0</querydsl.version>
         <jackson.version>2.16.0</jackson.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <lombok.version>1.18.30</lombok.version>
     </properties>
 
     <dependencies>
@@ -107,7 +108,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -133,12 +134,57 @@
             </plugin>
 
             <plugin>
+                <groupId>com.mysema.maven</groupId>
+                <artifactId>apt-maven-plugin</artifactId>
+                <version>1.1.3</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>target/generated-sources/java</outputDirectory>
+                            <processor>com.querydsl.apt.jpa.JPAAnnotationProcessor</processor>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.querydsl</groupId>
+                        <artifactId>querydsl-apt</artifactId>
+                        <version>5.0.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.12.1</version>
+
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <compilerArgs>
+                        <arg>-Amapstruct.defaultComponentModel=spring</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
 

--- a/src/main/java/ru/cobp/backend/controller/bank/BankController.java
+++ b/src/main/java/ru/cobp/backend/controller/bank/BankController.java
@@ -112,7 +112,7 @@ public class BankController {
             )}
     )})
     @DeleteMapping("/{bic}")
-    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable String bic) {
         bankService.deleteByBic(bic);
     }

--- a/src/main/java/ru/cobp/backend/controller/bank/BankController.java
+++ b/src/main/java/ru/cobp/backend/controller/bank/BankController.java
@@ -7,13 +7,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import ru.cobp.backend.dto.bank.BankResponseDto;
-import ru.cobp.backend.dto.bank.NewBankDto;
+import ru.cobp.backend.dto.bank.BankCreateUpdateDto;
+import ru.cobp.backend.dto.bank.BankSort;
 import ru.cobp.backend.mapper.BankMapper;
 import ru.cobp.backend.model.bank.Bank;
 import ru.cobp.backend.service.bank.BankService;
@@ -29,6 +32,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/v1/banks")
 @RequiredArgsConstructor
+@Validated
 public class BankController {
 
     private final BankService bankService;
@@ -37,25 +41,79 @@ public class BankController {
 
     private final BankMapper bankMapper;
 
+    @Operation(
+            summary = "Добавление нового банка",
+            description = "Конечная точка для добавления нового банка"
+    )
+    @ApiResponses(value = {@ApiResponse(
+            responseCode = "201",
+            description = "Добавлен новый банк",
+            content = {@Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BankResponseDto.class)
+            )}
+    )})
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public NewBankDto create(@RequestBody NewBankDto newBankDto) {
-        return bankService.create(newBankDto);
+    public BankResponseDto create(@RequestBody @Valid BankCreateUpdateDto newBankDto) {
+        Bank newBank = bankMapper.fromBankCreateUpdateDto(newBankDto);
+        Bank response = bankService.create(newBank);
+        return bankMapper.toBankResponseDto(response);
     }
 
+    @Operation(
+            summary = "Обновление данных по банку",
+            description = "Конечная точка для обновления данных по банку"
+    )
+    @ApiResponses(value = {@ApiResponse(
+            responseCode = "200",
+            description = "Данные по банку обновлены",
+            content = {@Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BankResponseDto.class)
+            )}
+    )})
     @PutMapping("/{bic}")
-    public NewBankDto update(@PathVariable Long bic, @RequestBody NewBankDto newBankDto) {
-        return bankService.update(bic, newBankDto);
+    public BankResponseDto update(@PathVariable String bic,
+                                  @RequestBody @Valid BankCreateUpdateDto updateBankDto) {
+        Bank updateBank = bankMapper.fromBankCreateUpdateDto(updateBankDto);
+        Bank response = bankService.update(bic, updateBank);
+        return bankMapper.toBankResponseDto(response);
     }
 
+    @Operation(
+            summary = "Получить банк по БИК номеру",
+            description = "Конечная точка для получения банка по БИК номеру"
+    )
+    @ApiResponses(value = {@ApiResponse(
+            responseCode = "200",
+            description = "Получен банк по БИК номеру",
+            content = {@Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BankResponseDto.class)
+            )}
+    )})
     @GetMapping("/{bic}")
-    public BankResponseDto getByBic(@PathVariable Long bic) {
-        Bank bank = bankService.getByBic(bic);
+    public BankResponseDto getByBic(@PathVariable String bic) {
+        Bank bank = bankService.getBankByBicOrThrowException(bic);
         return bankMapper.toBankResponseDto(bank);
     }
 
+    @Operation(
+            summary = "Удалить банк по БИК номеру",
+            description = "Конечная точка для удаления банка по БИК номеру"
+    )
+    @ApiResponses(value = {@ApiResponse(
+            responseCode = "204",
+            description = "Удален банк по БИК номеру",
+            content = {@Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BankResponseDto.class)
+            )}
+    )})
     @DeleteMapping("/{bic}")
-    public void delete(@PathVariable Long bic) {
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public void delete(@PathVariable String bic) {
         bankService.deleteByBic(bic);
     }
 
@@ -72,8 +130,8 @@ public class BankController {
             )}
     )})
     @GetMapping
-    public List<BankResponseDto> getAll() {
-        List<Bank> banks = bankService.getAll();
+    public List<BankResponseDto> getAll(@RequestParam(required = false) BankSort sort) {
+        List<Bank> banks = bankService.getAll(sort);
         return bankMapper.toBankResponseDtos(banks);
     }
 

--- a/src/main/java/ru/cobp/backend/dto/bank/BankCreateUpdateDto.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankCreateUpdateDto.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class NewBankDto {
+public class BankCreateUpdateDto {
 
     @NotNull
     private String bic;

--- a/src/main/java/ru/cobp/backend/dto/bank/BankSort.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankSort.java
@@ -1,0 +1,6 @@
+package ru.cobp.backend.dto.bank;
+
+public enum BankSort {
+    CREDITS,
+    DEPOSITS
+}

--- a/src/main/java/ru/cobp/backend/dto/credit/NewCreditDto.java
+++ b/src/main/java/ru/cobp/backend/dto/credit/NewCreditDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class NewCreditDto {
 
     @NotNull
-    private Long banksBic;
+    private String banksBic;
 
     @NotBlank
     @Size(min = 3, max = 100)

--- a/src/main/java/ru/cobp/backend/dto/credit/NewCreditDto.java
+++ b/src/main/java/ru/cobp/backend/dto/credit/NewCreditDto.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class NewCreditDto {
 
     @NotNull
-    private String banksBic;
+    private String bankBic;
 
     @NotBlank
     @Size(min = 3, max = 100)

--- a/src/main/java/ru/cobp/backend/exception/DuplicateException.java
+++ b/src/main/java/ru/cobp/backend/exception/DuplicateException.java
@@ -1,0 +1,7 @@
+package ru.cobp.backend.exception;
+
+public class DuplicateException extends RuntimeException {
+    public DuplicateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ru/cobp/backend/exception/ExceptionHandlerController.java
+++ b/src/main/java/ru/cobp/backend/exception/ExceptionHandlerController.java
@@ -47,4 +47,11 @@ public class ExceptionHandlerController {
         return new ResponseEntity<>(errorResponse, httpStatus);
     }
 
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponseDto handle(DuplicateException ex) {
+        log.error(ex.getMessage(), ex);
+        return new ErrorResponseDto(LocalDateTime.now(), ex.getMessage());
+    }
+
 }

--- a/src/main/java/ru/cobp/backend/exception/ExceptionMessage.java
+++ b/src/main/java/ru/cobp/backend/exception/ExceptionMessage.java
@@ -12,4 +12,8 @@ public class ExceptionMessage {
 
     public static final String LOGO_FILE_NOT_FOUND = "Logo file not found";
 
+    public static final String BANK_NOT_FOUND = "Bank with BIC %s not found";
+
+    public static final String DUPLICATE_EXCEPTION = "Object of type %s already exists";
+
 }

--- a/src/main/java/ru/cobp/backend/mapper/BankMapper.java
+++ b/src/main/java/ru/cobp/backend/mapper/BankMapper.java
@@ -4,6 +4,7 @@ import org.mapstruct.Mapper;
 import org.springframework.stereotype.Component;
 import ru.cobp.backend.dto.bank.BankResponseDto;
 import ru.cobp.backend.dto.bank.BankShortResponseDto;
+import ru.cobp.backend.dto.bank.BankCreateUpdateDto;
 import ru.cobp.backend.model.bank.Bank;
 
 import java.util.List;
@@ -17,5 +18,7 @@ public interface BankMapper {
     BankResponseDto toBankResponseDto(Bank bank);
 
     BankShortResponseDto toBankShortResponseDto(Bank bank);
+
+    Bank fromBankCreateUpdateDto(BankCreateUpdateDto createUpdateDto);
 
 }

--- a/src/main/java/ru/cobp/backend/repository/bank/BankRepository.java
+++ b/src/main/java/ru/cobp/backend/repository/bank/BankRepository.java
@@ -5,6 +5,11 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 import ru.cobp.backend.model.bank.Bank;
 
+import java.util.Optional;
+
 @Repository
 public interface BankRepository extends JpaRepository<Bank, Long>, QuerydslPredicateExecutor<Bank> {
+    Optional<Bank> findByBic(String bic);
+
+    void deleteByBic(String bic);
 }

--- a/src/main/java/ru/cobp/backend/repository/bank/BankRepository.java
+++ b/src/main/java/ru/cobp/backend/repository/bank/BankRepository.java
@@ -5,11 +5,6 @@ import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 import ru.cobp.backend.model.bank.Bank;
 
-import java.util.Optional;
-
 @Repository
-public interface BankRepository extends JpaRepository<Bank, Long>, QuerydslPredicateExecutor<Bank> {
-    Optional<Bank> findByBic(String bic);
-
-    void deleteByBic(String bic);
+public interface BankRepository extends JpaRepository<Bank, String>, QuerydslPredicateExecutor<Bank> {
 }

--- a/src/main/java/ru/cobp/backend/service/bank/BankService.java
+++ b/src/main/java/ru/cobp/backend/service/bank/BankService.java
@@ -1,20 +1,19 @@
 package ru.cobp.backend.service.bank;
 
-import ru.cobp.backend.dto.bank.NewBankDto;
+import ru.cobp.backend.dto.bank.BankSort;
 import ru.cobp.backend.model.bank.Bank;
 
 import java.util.List;
 
 public interface BankService {
 
-    NewBankDto create(NewBankDto newBank);
+    Bank create(Bank newBank);
 
-    NewBankDto update(Long bic, NewBankDto updBank);
+    Bank update(String bic, Bank updBank);
 
-    Bank getByBic(Long bic);
+    Bank getBankByBicOrThrowException(String bic);
 
-    void deleteByBic(Long bic);
+    void deleteByBic(String bic);
 
-    List<Bank> getAll();
-
+    List<Bank> getAll(BankSort sort);
 }

--- a/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
@@ -16,7 +16,6 @@ import ru.cobp.backend.model.deposit.QDeposit;
 import ru.cobp.backend.repository.bank.BankRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -60,7 +59,7 @@ public class BankServiceImpl implements BankService {
 
     @Override
     public Bank getBankByBicOrThrowException(String bic) {
-        return bankRepository.findByBic(bic).orElseThrow(
+        return bankRepository.findById(bic).orElseThrow(
                 () -> new NotFoundException(
                         String.format(ExceptionMessage.BANK_NOT_FOUND, bic)
                 ));
@@ -70,7 +69,7 @@ public class BankServiceImpl implements BankService {
     @Transactional
     public void deleteByBic(String bic) {
         getBankByBicOrThrowException(bic);
-        bankRepository.deleteByBic(bic);
+        bankRepository.deleteById(bic);
     }
 
     @Override
@@ -99,8 +98,7 @@ public class BankServiceImpl implements BankService {
     }
 
     private void checkIfBankExistsByBic(String bic) {
-        Optional<Bank> optionalBank = bankRepository.findByBic(bic);
-        if (optionalBank.isPresent()) {
+        if (bankRepository.findById(bic).isPresent()) {
             throw new DuplicateException(
                     String.format(ExceptionMessage.DUPLICATE_EXCEPTION, Bank.class)
             );

--- a/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
@@ -1,44 +1,109 @@
 package ru.cobp.backend.service.bank;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import ru.cobp.backend.dto.bank.NewBankDto;
+import ru.cobp.backend.dto.bank.BankSort;
+import ru.cobp.backend.exception.DuplicateException;
+import ru.cobp.backend.exception.ExceptionMessage;
+import ru.cobp.backend.exception.NotFoundException;
 import ru.cobp.backend.model.bank.Bank;
+import ru.cobp.backend.model.bank.QBank;
+import ru.cobp.backend.model.credit.QCredit;
+import ru.cobp.backend.model.deposit.QDeposit;
 import ru.cobp.backend.repository.bank.BankRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class BankServiceImpl implements BankService {
-
+    private static final QBank Q_BANK = QBank.bank;
+    private static final QCredit Q_CREDIT = QCredit.credit;
+    private static final QDeposit Q_DEPOSIT = QDeposit.deposit;
     private final BankRepository bankRepository;
 
     @Override
-    public NewBankDto create(NewBankDto newBank) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    @Transactional
+    public Bank create(Bank newBank) {
+        checkIfBankExistsByBic(newBank.getBic());
+        return bankRepository.save(newBank);
     }
 
     @Override
-    public NewBankDto update(Long bic, NewBankDto updBank) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    @Transactional
+    public Bank update(String bic, Bank updateBank) {
+        Bank bank = getBankByBicOrThrowException(bic);
+
+        if (updateBank.getName() != null) {
+            bank.setName(updateBank.getName());
+        }
+        if (updateBank.getLegalEntity() != null) {
+            bank.setLegalEntity(updateBank.getLegalEntity());
+        }
+        if (updateBank.getDescription() != null) {
+            bank.setDescription(updateBank.getDescription());
+        }
+        if (updateBank.getLogo() != null) {
+            bank.setLogo(updateBank.getLogo());
+        }
+        if (updateBank.getUrl() != null) {
+            bank.setUrl(updateBank.getUrl());
+        }
+
+        return bankRepository.save(bank);
     }
 
     @Override
-    public Bank getByBic(Long bic) {
-        throw new UnsupportedOperationException("Not implemented yet");
+    public Bank getBankByBicOrThrowException(String bic) {
+        return bankRepository.findByBic(bic).orElseThrow(
+                () -> new NotFoundException(
+                        String.format(ExceptionMessage.BANK_NOT_FOUND, bic)
+                ));
     }
 
     @Override
-    public void deleteByBic(Long bic) {
-
+    @Transactional
+    public void deleteByBic(String bic) {
+        getBankByBicOrThrowException(bic);
+        bankRepository.deleteByBic(bic);
     }
 
     @Override
-    public List<Bank> getAll() {
-        return bankRepository.findAll();
+    public List<Bank> getAll(BankSort sort) {
+        if (sort == null) {
+            return bankRepository.findAll();
+        } else {
+            BooleanExpression expression;
+            if (sort.equals(BankSort.CREDITS)) {
+                expression = Q_BANK.in(
+                        JPAExpressions
+                                .select(Q_CREDIT.bank)
+                                .from(Q_CREDIT)
+                                .where(Q_CREDIT.bank.isNotNull())
+                );
+            } else {
+                expression = Q_BANK.in(
+                        JPAExpressions
+                                .select(Q_DEPOSIT.bank)
+                                .from(Q_DEPOSIT)
+                                .where(Q_DEPOSIT.bank.isNotNull())
+                );
+            }
+            return (List<Bank>) bankRepository.findAll(expression);
+        }
     }
 
+    private void checkIfBankExistsByBic(String bic) {
+        Optional<Bank> optionalBank = bankRepository.findByBic(bic);
+        if (optionalBank.isPresent()) {
+            throw new DuplicateException(
+                    String.format(ExceptionMessage.DUPLICATE_EXCEPTION, Bank.class)
+            );
+        }
+    }
 }

--- a/src/main/java/ru/cobp/backend/service/credit/CreditServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/credit/CreditServiceImpl.java
@@ -60,7 +60,7 @@ public class CreditServiceImpl implements CreditService {
 
     @Override
     public Credit create(NewCreditDto newCreditDto) {
-        Bank bank = bankService.getByBic(newCreditDto.getBanksBic());
+        Bank bank = bankService.getBankByBicOrThrowException(newCreditDto.getBanksBic());
         Currency currency = currencyService.getById(newCreditDto.getCurrencyNum());
         Credit credit = toCredit(newCreditDto, bank, currency);
         return creditRepository.save(credit);

--- a/src/main/java/ru/cobp/backend/service/credit/CreditServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/credit/CreditServiceImpl.java
@@ -60,7 +60,7 @@ public class CreditServiceImpl implements CreditService {
 
     @Override
     public Credit create(NewCreditDto newCreditDto) {
-        Bank bank = bankService.getBankByBicOrThrowException(newCreditDto.getBanksBic());
+        Bank bank = bankService.getBankByBicOrThrowException(newCreditDto.getBankBic());
         Currency currency = currencyService.getById(newCreditDto.getCurrencyNum());
         Credit credit = toCredit(newCreditDto, bank, currency);
         return creditRepository.save(credit);

--- a/src/test/java/ru/cobp/backend/controller/bank/BankControllerTest.java
+++ b/src/test/java/ru/cobp/backend/controller/bank/BankControllerTest.java
@@ -1,0 +1,230 @@
+package ru.cobp.backend.controller.bank;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import ru.cobp.backend.dto.bank.BankCreateUpdateDto;
+import ru.cobp.backend.dto.bank.BankResponseDto;
+import ru.cobp.backend.dto.bank.BankSort;
+import ru.cobp.backend.exception.DuplicateException;
+import ru.cobp.backend.exception.NotFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class BankControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    static BankCreateUpdateDto createUpdateDto;
+    static List<String> bics = List.of("044525111", "044525187", "044525225", "044525593", "044525823", "044525974");
+
+    static Stream<Arguments> banksSearchInputsForParameterisedTest() {
+        return Stream.of(
+                Arguments.of(BankSort.DEPOSITS, List.of("044525187", "044525823", "044525974")),
+                Arguments.of(BankSort.CREDITS, bics)
+        );
+    }
+
+    @BeforeEach
+    void init() {
+        createUpdateDto = BankCreateUpdateDto.builder()
+                .bic("123456789")
+                .name("bank name")
+                .description("description")
+                .legalEntity("legal entity")
+                .logo("logo.svg")
+                .url("https://url.com")
+                .build();
+    }
+
+    @Test
+    void create_whenValidCreateDto_shouldAddNewBank() {
+        // given
+        BankResponseDto expect = createBank(createUpdateDto);
+
+        // when
+        BankResponseDto actual = getBankByBic(createUpdateDto.getBic());
+
+        // then
+        compareExpectAndActualBankResponseDtos(expect, actual);
+    }
+
+    @Test
+    @SneakyThrows
+    void create_whenBicNotUnique_throwDuplicateException() {
+        // given
+        createUpdateDto.setBic("044525111");
+
+        // then
+        mockMvc.perform(post("/v1/banks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUpdateDto)))
+                .andExpect(result -> assertTrue(result.getResolvedException()
+                        instanceof DuplicateException));
+    }
+
+    @Test
+    void update_whenValidUpdateDto_thenReturnUpdatedResponse() {
+        // given
+        createUpdateDto.setBic("044525111");
+        BankResponseDto expect = updateBank(createUpdateDto.getBic(), createUpdateDto);
+
+        // when
+        BankResponseDto actual = getBankByBic(createUpdateDto.getBic());
+
+        // then
+        compareExpectAndActualBankResponseDtos(expect, actual);
+    }
+
+    @Test
+    @SneakyThrows
+    void update_whenBicInvalid_throwNotFoundException() {
+        // given
+        String invalidBic = "123456789";
+
+        // then
+        mockMvc.perform(put("/v1/banks/{bic}", invalidBic)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUpdateDto)))
+                .andExpect(result -> assertTrue(result.getResolvedException()
+                        instanceof NotFoundException));
+    }
+
+    @Test
+    @SneakyThrows
+    void getByBic_whenBicInvalid_throwNotFoundException() {
+        // given
+        String invalidBic = "123456789";
+
+        // then
+        mockMvc.perform(get("/v1/banks/{bic}", invalidBic)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(result -> assertTrue(result.getResolvedException()
+                        instanceof NotFoundException));
+    }
+
+    @Test
+    @SneakyThrows
+    void delete_whenBicInvalid_throwNotFoundException() {
+        // given
+        String invalidBic = "123456789";
+
+        // then
+        mockMvc.perform(delete("/v1/banks/{bic}", invalidBic)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(result -> assertTrue(result.getResolvedException()
+                        instanceof NotFoundException));
+    }
+
+    @ParameterizedTest
+    @MethodSource("banksSearchInputsForParameterisedTest")
+    @SneakyThrows
+    void getAll_whenSearch_thenReturnBanks(BankSort sort, List<String> expectedBics) {
+        // given
+        List<BankResponseDto> expected = getBanksByBics(expectedBics);
+
+        // when
+        List<BankResponseDto> actual = getBanksBySortParameter(sort);
+
+        // then
+        performAssertions(expected, actual);
+    }
+
+    List<BankResponseDto> getBanksByBics(List<String> bics) {
+        List<BankResponseDto> banks = new ArrayList<>();
+        for (String bic : bics) banks.add(getBankByBic(bic));
+        return banks;
+    }
+
+    @SneakyThrows
+    List<BankResponseDto> getBanksBySortParameter(BankSort sort) {
+        MvcResult result = mockMvc.perform(get("/v1/banks")
+                        .param("sort", String.valueOf(sort))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return List.of(objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                BankResponseDto[].class));
+    }
+
+    @SneakyThrows
+    BankResponseDto getBankByBic(String bic) {
+        MvcResult result = mockMvc.perform(get("/v1/banks/{bic}", bic)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                BankResponseDto.class);
+    }
+
+    void performAssertions(List<BankResponseDto> expect, List<BankResponseDto> actual) {
+        assertEquals(expect.size(), actual.size());
+
+        for (int i = 0; i < expect.size(); i++) {
+            BankResponseDto expectBank = expect.get(i);
+            BankResponseDto actualBank = actual.get(i);
+            compareExpectAndActualBankResponseDtos(expectBank, actualBank);
+        }
+    }
+
+    void compareExpectAndActualBankResponseDtos(BankResponseDto expectBank, BankResponseDto actualBank) {
+        assertEquals(expectBank.getBic(), actualBank.getBic());
+        assertEquals(expectBank.getName(), actualBank.getName());
+        assertEquals(expectBank.getDescription(), actualBank.getDescription());
+        assertEquals(expectBank.getLegalEntity(), actualBank.getLegalEntity());
+        assertEquals(expectBank.getLogo(), actualBank.getLogo());
+        assertEquals(expectBank.getUrl(), actualBank.getUrl());
+    }
+
+    @SneakyThrows
+    BankResponseDto createBank(BankCreateUpdateDto createUpdateDto) {
+        MvcResult result = mockMvc.perform(post("/v1/banks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUpdateDto)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        return objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                BankResponseDto.class);
+    }
+
+    @SneakyThrows
+    BankResponseDto updateBank(String bic, BankCreateUpdateDto createUpdateDto) {
+        MvcResult result = mockMvc.perform(put("/v1/banks/{bic}", bic)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(createUpdateDto)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return objectMapper.readValue(
+                result.getResponse().getContentAsString(),
+                BankResponseDto.class);
+    }
+}

--- a/src/test/java/ru/cobp/backend/mapper/BankMapperTest.java
+++ b/src/test/java/ru/cobp/backend/mapper/BankMapperTest.java
@@ -1,8 +1,8 @@
 package ru.cobp.backend.mapper;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.bank.BankResponseDto;
 import ru.cobp.backend.dto.bank.BankShortResponseDto;
@@ -13,14 +13,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@SpringBootTest
 class BankMapperTest {
 
-    BankMapper bankMapper;
-
-    @BeforeEach
-    void setUp() {
-        bankMapper = Mappers.getMapper(BankMapper.class);
-    }
+    @Autowired
+    private BankMapper bankMapper;
 
     @Test
     void whenMapBank_expectBankResponseDto() {

--- a/src/test/java/ru/cobp/backend/mapper/CalculatorMapperTest.java
+++ b/src/test/java/ru/cobp/backend/mapper/CalculatorMapperTest.java
@@ -1,8 +1,8 @@
 package ru.cobp.backend.mapper;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.bank.BankShortResponseDto;
 import ru.cobp.backend.dto.calculator.CalculatedCreditResponseDto;
@@ -20,14 +20,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@SpringBootTest
 class CalculatorMapperTest {
 
-    CalculatorMapper calculatorMapper;
-
-    @BeforeEach
-    void setUp() {
-        calculatorMapper = Mappers.getMapper(CalculatorMapper.class);
-    }
+    @Autowired
+    private CalculatorMapper calculatorMapper;
 
     @Test
     void whenMapCalculatedDeposit_expectCalculatedDepositResponseDto() {

--- a/src/test/java/ru/cobp/backend/mapper/CreditMapperTest.java
+++ b/src/test/java/ru/cobp/backend/mapper/CreditMapperTest.java
@@ -1,8 +1,8 @@
 package ru.cobp.backend.mapper;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.bank.BankResponseDto;
 import ru.cobp.backend.dto.bank.BankShortResponseDto;
@@ -18,14 +18,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@SpringBootTest
 class CreditMapperTest {
 
-    CreditMapper creditMapper;
-
-    @BeforeEach
-    void setUp() {
-        creditMapper = Mappers.getMapper(CreditMapper.class);
-    }
+    @Autowired
+    private CreditMapper creditMapper;
 
     @Test
     void whenMapCredit_expectCreditResponseDto() {

--- a/src/test/java/ru/cobp/backend/mapper/CurrencyMapperTest.java
+++ b/src/test/java/ru/cobp/backend/mapper/CurrencyMapperTest.java
@@ -1,8 +1,8 @@
 package ru.cobp.backend.mapper;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.currency.CurrencyResponseDto;
 import ru.cobp.backend.model.currency.Currency;
@@ -12,14 +12,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@SpringBootTest
 class CurrencyMapperTest {
 
-    CurrencyMapper currencyMapper;
-
-    @BeforeEach
-    void setUp() {
-        currencyMapper = Mappers.getMapper(CurrencyMapper.class);
-    }
+    @Autowired
+    private CurrencyMapper currencyMapper;
 
     @Test
     void whenMapCurrency_expectCurrencyResponseDto() {

--- a/src/test/java/ru/cobp/backend/mapper/CurrencyRateMapperTest.java
+++ b/src/test/java/ru/cobp/backend/mapper/CurrencyRateMapperTest.java
@@ -1,8 +1,8 @@
 package ru.cobp.backend.mapper;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.currency.CurrencyRateResponseDto;
 import ru.cobp.backend.model.currency.Currency;
@@ -13,14 +13,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@SpringBootTest
 class CurrencyRateMapperTest {
 
-    CurrencyRateMapper currencyRateMapper;
-
-    @BeforeEach
-    void setUp() {
-        currencyRateMapper = Mappers.getMapper(CurrencyRateMapper.class);
-    }
+    @Autowired
+    private CurrencyRateMapper currencyRateMapper;
 
     @Test
     void whenMapCurrencyRate_expectCurrencyRateResponseDto() {

--- a/src/test/java/ru/cobp/backend/mapper/DepositMapperTest.java
+++ b/src/test/java/ru/cobp/backend/mapper/DepositMapperTest.java
@@ -1,8 +1,8 @@
 package ru.cobp.backend.mapper;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.bank.BankResponseDto;
 import ru.cobp.backend.dto.bank.BankShortResponseDto;
@@ -18,14 +18,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@SpringBootTest
 class DepositMapperTest {
 
-    DepositMapper depositMapper;
-
-    @BeforeEach
-    void setUp() {
-        depositMapper = Mappers.getMapper(DepositMapper.class);
-    }
+    @Autowired
+    private DepositMapper depositMapper;
 
     @Test
     void whenMapDeposit_expectDepositResponseDto() {

--- a/src/test/java/ru/cobp/backend/service/credit/CreditServiceTest.java
+++ b/src/test/java/ru/cobp/backend/service/credit/CreditServiceTest.java
@@ -93,7 +93,7 @@ public class CreditServiceTest {
         Currency currency = TestUtils.buildRubCurrency();
         Credit expectedCredit = TestUtils.buildGazprombankCredit();
 
-        when(bankService.getByBic(newCreditDto.getBankBic())).thenReturn(bank);
+        when(bankService.getBankByBicOrThrowException(newCreditDto.getBankBic())).thenReturn(bank);
         when(currencyService.getById(newCreditDto.getCurrencyNum())).thenReturn(currency);
         when(creditRepository.save(any(Credit.class))).thenReturn(expectedCredit);
 
@@ -111,7 +111,7 @@ public class CreditServiceTest {
     void createCredit_whenBankOrCurrencyNotValid_thenNotFoundExceptionThrown() {
         NewCreditDto newCreditDto = TestUtils.buildNewGazprombankCreditDto();
 
-        when(bankService.getByBic(newCreditDto.getBankBic())).thenThrow(NotFoundException.class);
+        when(bankService.getBankByBicOrThrowException(newCreditDto.getBankBic())).thenThrow(NotFoundException.class);
 
         assertThrows(NotFoundException.class, () -> creditService.create(newCreditDto));
 


### PR DESCRIPTION
Начал отработку комментов, в основном коснулся банков: 

* Доработаны недостающие методы по сервису BankServiceImpl
* Добавлены сваггер аннотации для BankController
* Перенесем маппинг из сервиса в контроллер
* Исправлен нейминг для NewBankDto (теперь это более понятный BankCreateUpdateDto для методов POST / PUT)
* Поиск по банкам переделан с учетом запроса фронтов: теперь можно фильтровать поиск для кредитов и вкладов
* Добавлены интеграционные тесты для контроллера BankControllerTest

По тестам: сейчас покрытие ~80-90%, это достаточно для нас или хотим делать прям отдельно контроллер / сервис / репозиторий?
Почему спрашиваю, у нас достаточно простая CRUD логика пока реализована, кажется, что интеграционные тесты нормально справляются в целом. 

<img width="680" alt="Screenshot 2024-01-11 at 18 29 42" src="https://github.com/comparison-of-banking-products/cobp-backend/assets/118021621/c3ba097b-6877-4d8e-923d-d241aca49da4">

Получается PR закрывает полностью только таски 122 (фильтрация) и 124 (тесты банков), остальное в работе, завтра буду дальше смотреть, что можно править. 