### PR TITLE
feat: валидаторы для банков и валют

### DIFF
--- a/src/main/java/ru/cobp/backend/common/Constants.java
+++ b/src/main/java/ru/cobp/backend/common/Constants.java
@@ -12,14 +12,36 @@ public class Constants {
 
     public static final String ONLY_DIGITS_REGEXP = "\\d+";
 
-    public static final String NAME_REGEXP = "^[а-яА-Я-\\s]*$";
+    public static final String BANK_NAME_REGEXP = "^[а-яА-Я-\\s]*$";
+
+    public static final String DESCRIPTION_REGEXP = "^[0-9a-zA-Zа-яёЁА-Я-@#$.,?%^&+=!\"'«»\\s]*$";
+
+    public static final String LEGAL_ENTITY_REGEXP = "^[а-яА-Я-\"'«»\\s]*$";
+
+    public static final String LOGO_REGEXP = "^[а-яА-Яa-zA-Z-.]*$";
 
     public static final String URL_REGEXP = "(http(s)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)";
 
     public static final int URL_MAX_LENGTH = 100;
 
+    public static final int LOGO_MAX_LENGTH = 100;
+
+    public static final int LEGAL_ENTITY_MAX_LENGTH = 100;
+
+    public static final int BANK_NAME_MAX_LENGTH = 100;
+
+    public static final int CURRENCY_NAME_MAX_LENGTH = 100;
+
+    public static final int CODE_LENGTH = 3;
+
+    public static final int DESCRIPTION_MAX_LENGTH = 100;
+
     public static final int CURRENCY_NUM_LENGTH = 3;
 
     public static final String CURRENCY_NUM_REGEXP = "^[0-9]*$";
+
+    public static final String CURRENCY_CODE_REGEXP = "^[A-Z]*$";
+
+    public static final String CURRENCY_NAME_REGEXP = "^[а-яА-Я\\s]*$";
 
 }

--- a/src/main/java/ru/cobp/backend/controller/bank/BankController.java
+++ b/src/main/java/ru/cobp/backend/controller/bank/BankController.java
@@ -22,6 +22,7 @@ import ru.cobp.backend.mapper.BankMapper;
 import ru.cobp.backend.model.bank.Bank;
 import ru.cobp.backend.service.bank.BankService;
 import ru.cobp.backend.service.storage.StorageService;
+import ru.cobp.backend.validation.constraints.Bic;
 
 import java.util.List;
 
@@ -74,7 +75,7 @@ public class BankController {
             )}
     )})
     @PutMapping("/{bic}")
-    public BankResponseDto update(@PathVariable String bic,
+    public BankResponseDto update(@PathVariable @Bic String bic,
                                   @RequestBody @Valid BankCreateUpdateDto updateBankDto) {
         Bank oldBank = bankService.getBankByBicOrThrowException(bic);
         Bank updateBank = bankMapper.fromBankCreateUpdateDto(updateBankDto);
@@ -95,7 +96,7 @@ public class BankController {
             )}
     )})
     @GetMapping("/{bic}")
-    public BankResponseDto getByBic(@PathVariable String bic) {
+    public BankResponseDto getByBic(@PathVariable @Bic String bic) {
         Bank bank = bankService.getBankByBicOrThrowException(bic);
         return bankMapper.toBankResponseDto(bank);
     }
@@ -110,7 +111,7 @@ public class BankController {
     )})
     @DeleteMapping("/{bic}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable String bic) {
+    public void delete(@PathVariable @Bic String bic) {
         bankService.deleteByBic(bic);
     }
 
@@ -131,7 +132,7 @@ public class BankController {
             @RequestParam(required = false) BankSort sort,
 
             @Parameter(description = "Список БИК-ов")
-            @RequestParam(defaultValue = "") List<String> bics
+            @RequestParam(defaultValue = "") List<@Bic String> bics
     ) {
         List<Bank> banks = bankService.getAll(sort, bics);
         return bankMapper.toBankResponseDtos(banks);

--- a/src/main/java/ru/cobp/backend/controller/bank/BankController.java
+++ b/src/main/java/ru/cobp/backend/controller/bank/BankController.java
@@ -78,9 +78,8 @@ public class BankController {
                                   @RequestBody @Valid BankCreateUpdateDto updateBankDto) {
         Bank oldBank = bankService.getBankByBicOrThrowException(bic);
         Bank updateBank = bankMapper.fromBankCreateUpdateDto(updateBankDto);
-        oldBank = bankMapper.updateBank(oldBank, updateBank);
-        Bank response = bankService.update(oldBank);
-        return bankMapper.toBankResponseDto(response);
+        bankMapper.updateBank(oldBank, updateBank);
+        return bankMapper.toBankResponseDto(bankService.update(oldBank));
     }
 
     @Operation(

--- a/src/main/java/ru/cobp/backend/controller/credit/CreditController.java
+++ b/src/main/java/ru/cobp/backend/controller/credit/CreditController.java
@@ -58,7 +58,7 @@ public class CreditController {
     @GetMapping
     public List<CreditResponseDto> getAll(
             @RequestParam(required = false) @Parameter(description = "Доступность предложения") Boolean isActive,
-            @RequestParam(required = false) @Parameter(description = "Код валюты") Long currencyNum,
+            @RequestParam(required = false) @Parameter(description = "Код валюты") String currencyNum,
             @RequestParam(required = false) @Parameter(description = "Минимальная сумма кредита") Integer minAmount,
             @RequestParam(required = false) @Parameter(description = "Максимальная сумма кредита") Integer maxAmount,
             @RequestParam(required = false) @Parameter(description = "Кредитная ставка") Double rate,

--- a/src/main/java/ru/cobp/backend/controller/currency/CurrencyController.java
+++ b/src/main/java/ru/cobp/backend/controller/currency/CurrencyController.java
@@ -82,7 +82,7 @@ public class CurrencyController {
             )}
     )})
     @PutMapping("/{num}")
-    public CurrencyResponseDto update(@PathVariable Long num,
+    public CurrencyResponseDto update(@PathVariable String num,
                                       @RequestBody @Valid CurrencyCreateUpdateDto updateCurrencyDto) {
         Currency oldCurrency = currencyService.getById(num);
         Currency updateCurrency = currencyMapper.fromCurrencyCreateUpdateDto(updateCurrencyDto);
@@ -122,7 +122,7 @@ public class CurrencyController {
             )}
     )})
     @GetMapping("/{num}")
-    public CurrencyResponseDto getById(@PathVariable Long num) {
+    public CurrencyResponseDto getById(@PathVariable String num) {
         Currency response = currencyService.getById(num);
         return currencyMapper.toCurrencyResponseDto(response);
     }
@@ -137,7 +137,7 @@ public class CurrencyController {
     )})
     @DeleteMapping("/{num}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable Long num) {
+    public void delete(@PathVariable String num) {
         currencyService.deleteById(num);
     }
 

--- a/src/main/java/ru/cobp/backend/controller/currency/CurrencyController.java
+++ b/src/main/java/ru/cobp/backend/controller/currency/CurrencyController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +30,7 @@ import ru.cobp.backend.model.currency.Currency;
 import ru.cobp.backend.model.currency.CurrencyRate;
 import ru.cobp.backend.service.currency.CurrencyRatesService;
 import ru.cobp.backend.service.currency.CurrencyService;
+import ru.cobp.backend.validation.constraints.CurrencyNum;
 
 import java.util.List;
 
@@ -36,6 +38,7 @@ import java.util.List;
         name = "Валюты",
         description = "Контроллер для работы с валютами"
 )
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(path = "/v1/currencies")
@@ -82,9 +85,9 @@ public class CurrencyController {
             )}
     )})
     @PutMapping("/{num}")
-    public CurrencyResponseDto update(@PathVariable String num,
+    public CurrencyResponseDto update(@PathVariable @CurrencyNum String num,
                                       @RequestBody @Valid CurrencyCreateUpdateDto updateCurrencyDto) {
-        Currency oldCurrency = currencyService.getById(num);
+        Currency oldCurrency = currencyService.getByNum(num);
         Currency updateCurrency = currencyMapper.fromCurrencyCreateUpdateDto(updateCurrencyDto);
         oldCurrency = currencyMapper.updateCurrency(oldCurrency, updateCurrency);
         Currency response = currencyService.update(oldCurrency);
@@ -122,8 +125,8 @@ public class CurrencyController {
             )}
     )})
     @GetMapping("/{num}")
-    public CurrencyResponseDto getById(@PathVariable String num) {
-        Currency response = currencyService.getById(num);
+    public CurrencyResponseDto getById(@PathVariable @CurrencyNum String num) {
+        Currency response = currencyService.getByNum(num);
         return currencyMapper.toCurrencyResponseDto(response);
     }
 
@@ -137,7 +140,7 @@ public class CurrencyController {
     )})
     @DeleteMapping("/{num}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable String num) {
+    public void delete(@PathVariable @CurrencyNum String num) {
         currencyService.deleteById(num);
     }
 

--- a/src/main/java/ru/cobp/backend/dto/bank/BankCreateUpdateDto.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankCreateUpdateDto.java
@@ -1,7 +1,8 @@
 package ru.cobp.backend.dto.bank;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Schema(description = "Данные для создания / обновления банка")
 @Builder
 @Getter
 @Setter
@@ -16,31 +18,39 @@ import lombok.Setter;
 @NoArgsConstructor
 public class BankCreateUpdateDto {
 
-    @Schema(description = "БИК")
-    @NotNull(message = "Необходимо указать БИК банка")
+    @Schema(description = "БИК, уникальный идентификатор банка в системе Центробанка")
+    @NotBlank(message = "Необходимо указать БИК банка")
+    @Pattern(regexp = "[0-9]*$", message = "БИК должен состоять из чисел от 0 до 9")
+    @Size(min = 9, max = 9, message = "БИК должен состоять из 9 символов")
     private String bic;
 
-    @Schema(description = "Название")
-    @NotNull(message = "Необходимо указать название банка")
-    @Size(max = 100)
+    @Schema(description = "Сокращенное название банка")
+    @NotBlank(message = "Необходимо указать сокращенное название банка")
+    @Pattern(regexp = "^[а-яА-Я-\\s]*$", message = "Название может состоять из символов русского алфавита, дефиса")
+    @Size(max = 100, message = "Максимальная длина названия 100 символов")
     private String name;
 
-    @Schema(description = "Юридическое лицо")
-    @NotNull(message = "Необходимо указать полное юридическое лицо")
-    @Size(max = 100)
+    @Schema(description = "Полное наименование банка (юридическое лицо)")
+    @NotBlank(message = "Необходимо указать полное юридическое лицо")
+    @Pattern(regexp = "^[а-яА-Я-\"'«»\\s]*$",
+            message = "Юридическое лицо банка может состоять из символов русского алфавита, дефиса, кавычек")
+    @Size(max = 100, message = "Максимальная длина юридического лица 100 символов")
     private String legalEntity;
 
-    @Schema(description = "Описание")
-    @NotNull(message = "Необходимо указать описание банка")
+    @Schema(description = "Информация о банке")
+    @NotBlank(message = "Необходимо указать описание банка")
+    @Pattern(regexp = "^[0-9a-zA-Zа-яёЁА-Я-@#$.,?%^&+=!\"'«»\\s]*$",
+            message = "Описание банка может содержать только символьно-числовые значения")
+    @Size(max = 1000, message = "Максимальная длина описания 1000 символов")
     private String description;
 
-    @Schema(description = "Лого")
-    @NotNull(message = "Необходимо указать лого банка")
-    @Size(max = 100)
+    @Schema(description = "Логотип банка")
+    @NotBlank(message = "Необходимо указать ссылку на файл")
+    @Size(max = 1000, message = "Максимальная длина ссылки на файл 1000 символов")
     private String logo;
 
-    @Schema(description = "Онлайн-адрес")
-    @NotNull(message = "Необходимо указать онлайн-адрес банка")
-    @Size(max = 100)
+    @Schema(description = "Наименование сайта банка")
+    @NotBlank(message = "Необходимо указать сайт банка")
+    @Size(max = 100, message = "Максимальная длина сайта 100 символов")
     private String url;
 }

--- a/src/main/java/ru/cobp/backend/dto/bank/BankCreateUpdateDto.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankCreateUpdateDto.java
@@ -1,14 +1,17 @@
 package ru.cobp.backend.dto.bank;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import ru.cobp.backend.validation.constraints.Description;
+import ru.cobp.backend.validation.constraints.BankName;
+import ru.cobp.backend.validation.constraints.Bic;
+import ru.cobp.backend.validation.constraints.LegalEntity;
+import ru.cobp.backend.validation.constraints.Logo;
+import ru.cobp.backend.validation.constraints.Url;
 
 @Schema(description = "Данные для создания / обновления банка")
 @Builder
@@ -18,39 +21,27 @@ import lombok.Setter;
 @NoArgsConstructor
 public class BankCreateUpdateDto {
 
-    @Schema(description = "БИК, уникальный идентификатор банка в системе Центробанка")
-    @NotBlank(message = "Необходимо указать БИК банка")
-    @Pattern(regexp = "[0-9]*$", message = "БИК должен состоять из чисел от 0 до 9")
-    @Size(min = 9, max = 9, message = "БИК должен состоять из 9 символов")
+    @Schema(description = "БИК")
+    @Bic
     private String bic;
 
     @Schema(description = "Сокращенное название банка")
-    @NotBlank(message = "Необходимо указать сокращенное название банка")
-    @Pattern(regexp = "^[а-яА-Я-\\s]*$", message = "Название может состоять из символов русского алфавита, дефиса")
-    @Size(max = 100, message = "Максимальная длина названия 100 символов")
+    @BankName
     private String name;
 
     @Schema(description = "Полное наименование банка (юридическое лицо)")
-    @NotBlank(message = "Необходимо указать полное юридическое лицо")
-    @Pattern(regexp = "^[а-яА-Я-\"'«»\\s]*$",
-            message = "Юридическое лицо банка может состоять из символов русского алфавита, дефиса, кавычек")
-    @Size(max = 100, message = "Максимальная длина юридического лица 100 символов")
+    @LegalEntity
     private String legalEntity;
 
     @Schema(description = "Информация о банке")
-    @NotBlank(message = "Необходимо указать описание банка")
-    @Pattern(regexp = "^[0-9a-zA-Zа-яёЁА-Я-@#$.,?%^&+=!\"'«»\\s]*$",
-            message = "Описание банка может содержать только символьно-числовые значения")
-    @Size(max = 1000, message = "Максимальная длина описания 1000 символов")
+    @Description
     private String description;
 
     @Schema(description = "Логотип банка")
-    @NotBlank(message = "Необходимо указать ссылку на файл")
-    @Size(max = 1000, message = "Максимальная длина ссылки на файл 1000 символов")
+    @Logo
     private String logo;
 
     @Schema(description = "Наименование сайта банка")
-    @NotBlank(message = "Необходимо указать сайт банка")
-    @Size(max = 100, message = "Максимальная длина сайта 100 символов")
+    @Url
     private String url;
 }

--- a/src/main/java/ru/cobp/backend/dto/bank/BankResponseDto.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankResponseDto.java
@@ -11,22 +11,22 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class BankResponseDto {
 
-    @Schema(description = "БИК")
+    @Schema(description = "БИК, уникальный идентификатор банка в системе Центробанка")
     private String bic;
 
-    @Schema(description = "Название")
+    @Schema(description = "Сокращенное название банка")
     private String name;
 
-    @Schema(description = "Юридическое лицо")
+    @Schema(description = "Полное наименование банка с указанием организационно-правовой формы")
     private String legalEntity;
 
-    @Schema(description = "Описание")
+    @Schema(description = "Информация о банке")
     private String description;
 
-    @Schema(description = "Лого")
+    @Schema(description = "Логотип банка")
     private String logo;
 
-    @Schema(description = "Онлайн-адрес")
+    @Schema(description = "Наименование сайта банка")
     private String url;
 
 }

--- a/src/main/java/ru/cobp/backend/dto/bank/BankShortResponseDto.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankShortResponseDto.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class BankShortResponseDto {
 
-    @Schema(description = "Название банка")
+    @Schema(description = "Сокращенное название банка")
     private String name;
 
-    @Schema(description = "Лого банка")
+    @Schema(description = "Логотип банка")
     private String logo;
 
 }

--- a/src/main/java/ru/cobp/backend/dto/bank/BankSort.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankSort.java
@@ -1,6 +1,12 @@
 package ru.cobp.backend.dto.bank;
 
 public enum BankSort {
-    CREDITS,
-    DEPOSITS
+    CREDITS("Параметр сортировки банков с кредитами"),
+    DEPOSITS("Параметр сортировки банков с вкладами");
+
+    public final String label;
+
+    BankSort(String label) {
+        this.label = label;
+    }
 }

--- a/src/main/java/ru/cobp/backend/dto/bank/BankSort.java
+++ b/src/main/java/ru/cobp/backend/dto/bank/BankSort.java
@@ -1,8 +1,8 @@
 package ru.cobp.backend.dto.bank;
 
 public enum BankSort {
-    CREDITS("Параметр сортировки банков с кредитами"),
-    DEPOSITS("Параметр сортировки банков с вкладами");
+    CREDITS("Параметр фильтрации банков с кредитами"),
+    DEPOSITS("Параметр фильтрации банков с вкладами");
 
     public final String label;
 

--- a/src/main/java/ru/cobp/backend/dto/credit/CreditParams.java
+++ b/src/main/java/ru/cobp/backend/dto/credit/CreditParams.java
@@ -10,7 +10,7 @@ public class CreditParams {
 
     Boolean isActive;
 
-    Long currencyNum;
+    String currencyNum;
 
     Integer minAmount;
 

--- a/src/main/java/ru/cobp/backend/dto/credit/NewCreditDto.java
+++ b/src/main/java/ru/cobp/backend/dto/credit/NewCreditDto.java
@@ -24,7 +24,7 @@ public class NewCreditDto {
     private Boolean isActive;
 
     @NotNull
-    private Long currencyNum;
+    private String currencyNum;
 
     @NotBlank
     @Size(min = 3, max = 100)

--- a/src/main/java/ru/cobp/backend/dto/currency/CurrencyCreateUpdateDto.java
+++ b/src/main/java/ru/cobp/backend/dto/currency/CurrencyCreateUpdateDto.java
@@ -1,6 +1,8 @@
 package ru.cobp.backend.dto.currency;
 
-import jakarta.validation.constraints.NotNull;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@Schema(description = "Данные для создания / обновления валюты")
 @Builder
 @Getter
 @Setter
@@ -15,14 +18,21 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CurrencyCreateUpdateDto {
 
-    @NotNull
-    private Long num;
+    @Schema(description = "Цифровой код валюты согласно общероссийскому классификатору валют")
+    @NotBlank(message = "Необоходимо указать цифровой код валюты")
+    @Pattern(regexp = "^[0-9]*$", message = "Цифровой код валюты состоит из символов от 0 до 9")
+    @Size(min = 3, max = 3, message = "Номер валюты должен состоять из 3 символов")
+    private String num;
 
-    @NotNull
-    @Size(min = 3, max = 3)
+    @Schema(description = "Буквенный код валюты согласно общероссийскому классификатору валют")
+    @NotBlank(message = "Необоходимо указать буквенный код валюты")
+    @Pattern(regexp = "^[A-Z]*$", message = "Буквенный код валюты состоит из символов латинского алфавита")
+    @Size(min = 3, max = 3, message = "Буквенный код валюты должен состоять из 3 символов")
     private String code;
 
-    @NotNull
-    @Size(max = 30)
+    @Schema(description = "Наименование валюты")
+    @NotBlank(message = "Необходимо указать наименование валюты")
+    @Pattern(regexp = "^[а-яА-Я\\s]*$", message = "Наименование валюты содержит только русские буквы и пробелы")
+    @Size(max = 100, message = "Максимальная длина наименования валюты 100 символов")
     private String currency;
 }

--- a/src/main/java/ru/cobp/backend/dto/currency/CurrencyCreateUpdateDto.java
+++ b/src/main/java/ru/cobp/backend/dto/currency/CurrencyCreateUpdateDto.java
@@ -1,14 +1,14 @@
 package ru.cobp.backend.dto.currency;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import ru.cobp.backend.validation.constraints.Code;
+import ru.cobp.backend.validation.constraints.CurrencyName;
+import ru.cobp.backend.validation.constraints.CurrencyNum;
 
 @Schema(description = "Данные для создания / обновления валюты")
 @Builder
@@ -18,21 +18,15 @@ import lombok.Setter;
 @NoArgsConstructor
 public class CurrencyCreateUpdateDto {
 
-    @Schema(description = "Цифровой код валюты согласно общероссийскому классификатору валют")
-    @NotBlank(message = "Необоходимо указать цифровой код валюты")
-    @Pattern(regexp = "^[0-9]*$", message = "Цифровой код валюты состоит из символов от 0 до 9")
-    @Size(min = 3, max = 3, message = "Номер валюты должен состоять из 3 символов")
+    @Schema(description = "Цифровой код валюты")
+    @CurrencyNum
     private String num;
 
-    @Schema(description = "Буквенный код валюты согласно общероссийскому классификатору валют")
-    @NotBlank(message = "Необоходимо указать буквенный код валюты")
-    @Pattern(regexp = "^[A-Z]*$", message = "Буквенный код валюты состоит из символов латинского алфавита")
-    @Size(min = 3, max = 3, message = "Буквенный код валюты должен состоять из 3 символов")
+    @Schema(description = "Буквенный код валюты")
+    @Code
     private String code;
 
     @Schema(description = "Наименование валюты")
-    @NotBlank(message = "Необходимо указать наименование валюты")
-    @Pattern(regexp = "^[а-яА-Я\\s]*$", message = "Наименование валюты содержит только русские буквы и пробелы")
-    @Size(max = 100, message = "Максимальная длина наименования валюты 100 символов")
+    @CurrencyName
     private String currency;
 }

--- a/src/main/java/ru/cobp/backend/dto/currency/CurrencyResponseDto.java
+++ b/src/main/java/ru/cobp/backend/dto/currency/CurrencyResponseDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class CurrencyResponseDto {
 
     @Schema(description = "Цифровой код")
-    private Long num;
+    private String num;
 
     @Schema(description = "Символьный код")
     private String code;

--- a/src/main/java/ru/cobp/backend/exception/ErrorResponseDto.java
+++ b/src/main/java/ru/cobp/backend/exception/ErrorResponseDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ErrorResponseDto {
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime timestamp;
 
     private String message;

--- a/src/main/java/ru/cobp/backend/exception/ErrorResponseDto.java
+++ b/src/main/java/ru/cobp/backend/exception/ErrorResponseDto.java
@@ -1,5 +1,6 @@
 package ru.cobp.backend.exception;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ErrorResponseDto {
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime timestamp;
 
     private String message;

--- a/src/main/java/ru/cobp/backend/exception/ExceptionHandlerController.java
+++ b/src/main/java/ru/cobp/backend/exception/ExceptionHandlerController.java
@@ -46,7 +46,7 @@ public class ExceptionHandlerController {
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.CONFLICT)
-    public ErrorResponseDto handle(DuplicateException ex) {
+    public ErrorResponseDto handle(final DuplicateException ex) {
         log.error(ex.getMessage(), ex);
         return new ErrorResponseDto(LocalDateTime.now(), ex.getMessage());
     }

--- a/src/main/java/ru/cobp/backend/exception/ExceptionHandlerController.java
+++ b/src/main/java/ru/cobp/backend/exception/ExceptionHandlerController.java
@@ -5,11 +5,14 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -49,6 +52,15 @@ public class ExceptionHandlerController {
     public ErrorResponseDto handle(final DuplicateException ex) {
         log.error(ex.getMessage(), ex);
         return new ErrorResponseDto(LocalDateTime.now(), ex.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public List<ErrorResponseDto> handle(final MethodArgumentNotValidException ex) {
+        List<ObjectError> errors = ex.getBindingResult().getAllErrors();
+        List<ErrorResponseDto> response = new ArrayList<>();
+        for (var e : errors) response.add(new ErrorResponseDto(LocalDateTime.now(), e.getDefaultMessage()));
+        return response;
     }
 
     @ExceptionHandler

--- a/src/main/java/ru/cobp/backend/exception/ExceptionMessage.java
+++ b/src/main/java/ru/cobp/backend/exception/ExceptionMessage.java
@@ -14,7 +14,7 @@ public class ExceptionMessage {
 
     public static final String BANK_NOT_FOUND = "Bank with BIC %s not found";
 
-    public static final String CURRENCY_NOT_FOUND = "Currency not found";
+    public static final String CURRENCY_NOT_FOUND = "Currency with num %s not found";
 
     public static final String DUPLICATE_EXCEPTION = "Object of type %s already exists";
 

--- a/src/main/java/ru/cobp/backend/exception/ExceptionUtil.java
+++ b/src/main/java/ru/cobp/backend/exception/ExceptionUtil.java
@@ -10,6 +10,18 @@ public class ExceptionUtil {
         return new DepositNotFoundException(ExceptionMessage.DEPOSIT_NOT_FOUND);
     }
 
+    public static NotFoundException getBankNotFoundException(String bic) {
+        return new NotFoundException(String.format(ExceptionMessage.BANK_NOT_FOUND, bic));
+    }
+
+    public static NotFoundException getCurrencyNotFoundException(String currencyNum) {
+        return new NotFoundException(String.format(ExceptionMessage.CURRENCY_NOT_FOUND, currencyNum));
+    }
+
+    public static <T> DuplicateException getDuplicateException(Class<T> clazz) {
+        return new DuplicateException(String.format(ExceptionMessage.DUPLICATE_EXCEPTION, clazz.getSimpleName()));
+    }
+
     public static ExchangeRatesProcessingFailedException getExchangeRatesProcessingFailedException(Throwable cause) {
         return new ExchangeRatesProcessingFailedException(ExceptionMessage.EXCHANGE_RATES_PROCESSING_FAILED, cause);
     }

--- a/src/main/java/ru/cobp/backend/mapper/BankMapper.java
+++ b/src/main/java/ru/cobp/backend/mapper/BankMapper.java
@@ -21,7 +21,7 @@ public interface BankMapper {
 
     Bank fromBankCreateUpdateDto(BankCreateUpdateDto createUpdateDto);
 
-    default Bank updateBank(Bank oldBank, Bank updateBank) {
+    default void updateBank(Bank oldBank, Bank updateBank) {
         if (updateBank.getName() != null) {
             oldBank.setName(updateBank.getName());
         }
@@ -37,6 +37,5 @@ public interface BankMapper {
         if (updateBank.getUrl() != null) {
             oldBank.setUrl(updateBank.getUrl());
         }
-        return oldBank;
     }
 }

--- a/src/main/java/ru/cobp/backend/model/currency/Currency.java
+++ b/src/main/java/ru/cobp/backend/model/currency/Currency.java
@@ -21,7 +21,7 @@ public class Currency {
 
     @Id
     @Column(name = "num", nullable = false)
-    private Long num;
+    private String num;
 
     @Column(name = "code", length = 3, nullable = false, unique = true)
     private String code;

--- a/src/main/java/ru/cobp/backend/repository/bank/BankRepository.java
+++ b/src/main/java/ru/cobp/backend/repository/bank/BankRepository.java
@@ -7,4 +7,5 @@ import ru.cobp.backend.model.bank.Bank;
 
 @Repository
 public interface BankRepository extends JpaRepository<Bank, String>, QuerydslPredicateExecutor<Bank> {
+    long deleteByBic(String bic);
 }

--- a/src/main/java/ru/cobp/backend/repository/currency/CurrencyRepository.java
+++ b/src/main/java/ru/cobp/backend/repository/currency/CurrencyRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 import ru.cobp.backend.model.currency.Currency;
 
 @Repository
-public interface CurrencyRepository extends JpaRepository<Currency, Long>, QuerydslPredicateExecutor<Currency> {
+public interface CurrencyRepository extends JpaRepository<Currency, String>, QuerydslPredicateExecutor<Currency> {
 }

--- a/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
@@ -51,12 +51,10 @@ public class BankServiceImpl implements BankService {
     @Override
     @Transactional
     public void deleteByBic(String bic) {
-        if (bankRepository.findById(bic).isEmpty()) {
-            throw new NotFoundException(
-                    String.format(ExceptionMessage.BANK_NOT_FOUND, bic)
-            );
+        long deleteCount = bankRepository.deleteByBic(bic);
+        if (deleteCount == 0) {
+            throw new NotFoundException(String.format(ExceptionMessage.BANK_NOT_FOUND, bic));
         }
-        bankRepository.deleteById(bic);
     }
 
     @Override

--- a/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/bank/BankServiceImpl.java
@@ -7,9 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ru.cobp.backend.dto.bank.BankSort;
-import ru.cobp.backend.exception.DuplicateException;
-import ru.cobp.backend.exception.ExceptionMessage;
-import ru.cobp.backend.exception.NotFoundException;
+import ru.cobp.backend.exception.ExceptionUtil;
 import ru.cobp.backend.model.bank.Bank;
 import ru.cobp.backend.model.bank.QBank;
 import ru.cobp.backend.model.credit.QCredit;
@@ -43,9 +41,7 @@ public class BankServiceImpl implements BankService {
     @Override
     public Bank getBankByBicOrThrowException(String bic) {
         return bankRepository.findById(bic).orElseThrow(
-                () -> new NotFoundException(
-                        String.format(ExceptionMessage.BANK_NOT_FOUND, bic)
-                ));
+                () -> ExceptionUtil.getBankNotFoundException(bic));
     }
 
     @Override
@@ -53,7 +49,7 @@ public class BankServiceImpl implements BankService {
     public void deleteByBic(String bic) {
         long deleteCount = bankRepository.deleteByBic(bic);
         if (deleteCount == 0) {
-            throw new NotFoundException(String.format(ExceptionMessage.BANK_NOT_FOUND, bic));
+            throw ExceptionUtil.getBankNotFoundException(bic);
         }
     }
 
@@ -90,9 +86,7 @@ public class BankServiceImpl implements BankService {
 
     private void checkIfBankExistsByBic(String bic) {
         if (bankRepository.findById(bic).isPresent()) {
-            throw new DuplicateException(
-                    String.format(ExceptionMessage.DUPLICATE_EXCEPTION, Bank.class)
-            );
+            throw ExceptionUtil.getDuplicateException(Bank.class);
         }
     }
 }

--- a/src/main/java/ru/cobp/backend/service/credit/CreditServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/credit/CreditServiceImpl.java
@@ -58,7 +58,7 @@ public class CreditServiceImpl implements CreditService {
     @Override
     public Credit create(NewCreditDto newCreditDto) {
         Bank bank = bankService.getBankByBicOrThrowException(newCreditDto.getBankBic());
-        Currency currency = currencyService.getById(newCreditDto.getCurrencyNum());
+        Currency currency = currencyService.getByNum(newCreditDto.getCurrencyNum());
         Credit credit = creditMapper.toCredit(newCreditDto);
         credit.setBank(bank);
         credit.setCurrency(currency);
@@ -125,7 +125,7 @@ public class CreditServiceImpl implements CreditService {
             builder.and(Q_CREDIT.isActive.eq(params.getIsActive()));
         }
         if (params.getCurrencyNum() != null) {
-            builder.and(Q_CREDIT.currency.eq(currencyService.getById(params.getCurrencyNum())));
+            builder.and(Q_CREDIT.currency.eq(currencyService.getByNum(params.getCurrencyNum())));
         }
         if (params.getMinAmount() != null) {
             builder.and(Q_CREDIT.amountMin.loe(params.getMinAmount()));

--- a/src/main/java/ru/cobp/backend/service/currency/CurrencyService.java
+++ b/src/main/java/ru/cobp/backend/service/currency/CurrencyService.java
@@ -10,7 +10,7 @@ public interface CurrencyService {
 
     Currency update(Currency updCurrency);
 
-    Currency getById(String currencyId);
+    Currency getByNum(String currencyNum);
 
     void deleteById(String currencyId);
 

--- a/src/main/java/ru/cobp/backend/service/currency/CurrencyService.java
+++ b/src/main/java/ru/cobp/backend/service/currency/CurrencyService.java
@@ -10,9 +10,9 @@ public interface CurrencyService {
 
     Currency update(Currency updCurrency);
 
-    Currency getById(Long currencyId);
+    Currency getById(String currencyId);
 
-    void deleteById(Long currencyId);
+    void deleteById(String currencyId);
 
     List<Currency> getAll();
 

--- a/src/main/java/ru/cobp/backend/service/currency/impl/CurrencyServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/currency/impl/CurrencyServiceImpl.java
@@ -31,7 +31,7 @@ public class CurrencyServiceImpl implements CurrencyService {
     }
 
     @Override
-    public Currency getById(Long currencyNum) {
+    public Currency getById(String currencyNum) {
         return currencyRepository.findById(currencyNum).orElseThrow(
                 () -> new NotFoundException(ExceptionMessage.CURRENCY_NOT_FOUND)
         );
@@ -39,7 +39,7 @@ public class CurrencyServiceImpl implements CurrencyService {
 
     @Override
     @Transactional
-    public void deleteById(Long currencyNum) {
+    public void deleteById(String currencyNum) {
         currencyRepository.deleteById(currencyNum);
     }
 

--- a/src/main/java/ru/cobp/backend/service/currency/impl/CurrencyServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/currency/impl/CurrencyServiceImpl.java
@@ -3,8 +3,7 @@ package ru.cobp.backend.service.currency.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import ru.cobp.backend.exception.ExceptionMessage;
-import ru.cobp.backend.exception.NotFoundException;
+import ru.cobp.backend.exception.ExceptionUtil;
 import ru.cobp.backend.model.currency.Currency;
 import ru.cobp.backend.repository.currency.CurrencyRepository;
 import ru.cobp.backend.service.currency.CurrencyService;
@@ -31,10 +30,9 @@ public class CurrencyServiceImpl implements CurrencyService {
     }
 
     @Override
-    public Currency getById(String currencyNum) {
+    public Currency getByNum(String currencyNum) {
         return currencyRepository.findById(currencyNum).orElseThrow(
-                () -> new NotFoundException(ExceptionMessage.CURRENCY_NOT_FOUND)
-        );
+                () -> ExceptionUtil.getCurrencyNotFoundException(currencyNum));
     }
 
     @Override

--- a/src/main/java/ru/cobp/backend/service/deposit/DepositServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/deposit/DepositServiceImpl.java
@@ -100,7 +100,7 @@ public class DepositServiceImpl implements DepositService {
     }
 
     private Currency getCurrency(String num) {
-        return currencyService.getById(num);
+        return currencyService.getByNum(num);
     }
 
     private void checkDepositExistsOrThrow(long id) {

--- a/src/main/java/ru/cobp/backend/service/deposit/DepositServiceImpl.java
+++ b/src/main/java/ru/cobp/backend/service/deposit/DepositServiceImpl.java
@@ -99,7 +99,7 @@ public class DepositServiceImpl implements DepositService {
         return bankService.getBankByBicOrThrowException(bic);
     }
 
-    private Currency getCurrency(long num) {
+    private Currency getCurrency(String num) {
         return currencyService.getById(num);
     }
 

--- a/src/main/java/ru/cobp/backend/validation/constraints/BankName.java
+++ b/src/main/java/ru/cobp/backend/validation/constraints/BankName.java
@@ -1,0 +1,29 @@
+package ru.cobp.backend.validation.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import ru.cobp.backend.common.Constants;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NotBlank(message = "{name.blank.invalid}")
+@Size(max = Constants.BANK_NAME_MAX_LENGTH, message = "{name.length.invalid}")
+@Pattern(regexp = Constants.BANK_NAME_REGEXP, message = "{name.content.invalid}")
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+public @interface BankName {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/ru/cobp/backend/validation/constraints/Code.java
+++ b/src/main/java/ru/cobp/backend/validation/constraints/Code.java
@@ -1,0 +1,29 @@
+package ru.cobp.backend.validation.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import ru.cobp.backend.common.Constants;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NotBlank(message = "{currency-code.blank.invalid}")
+@Size(max = Constants.CODE_LENGTH, message = "{currency-code.length.invalid}")
+@Pattern(regexp = Constants.CURRENCY_CODE_REGEXP, message = "{currency-code.content.invalid}")
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+public @interface Code {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/ru/cobp/backend/validation/constraints/CurrencyName.java
+++ b/src/main/java/ru/cobp/backend/validation/constraints/CurrencyName.java
@@ -1,0 +1,29 @@
+package ru.cobp.backend.validation.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import ru.cobp.backend.common.Constants;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NotBlank(message = "{currency-name.blank.invalid}")
+@Size(max = Constants.CURRENCY_NAME_MAX_LENGTH, message = "{currency-name.length.invalid}")
+@Pattern(regexp = Constants.CURRENCY_NAME_REGEXP, message = "{currency-name.content.invalid}")
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+public @interface CurrencyName {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/ru/cobp/backend/validation/constraints/Description.java
+++ b/src/main/java/ru/cobp/backend/validation/constraints/Description.java
@@ -1,0 +1,29 @@
+package ru.cobp.backend.validation.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import ru.cobp.backend.common.Constants;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NotBlank(message = "{description.blank.invalid}")
+@Size(max = Constants.DESCRIPTION_MAX_LENGTH, message = "{description.length.invalid}")
+@Pattern(regexp = Constants.DESCRIPTION_REGEXP, message = "{description.content.invalid}")
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+public @interface Description {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/ru/cobp/backend/validation/constraints/LegalEntity.java
+++ b/src/main/java/ru/cobp/backend/validation/constraints/LegalEntity.java
@@ -12,13 +12,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@NotBlank(message = "{name.blank.invalid}")
-@Size(max = 100, message = "{name.length.invalid}")
-@Pattern(regexp = Constants.NAME_REGEXP, message = "{name.content.invalid}")
+@NotBlank(message = "{legalEntity.blank.invalid}")
+@Size(max = Constants.LEGAL_ENTITY_MAX_LENGTH, message = "{legalEntity.length.invalid}")
+@Pattern(regexp = Constants.LEGAL_ENTITY_REGEXP, message = "{legalEntity.content.invalid}")
 @Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = {})
-public @interface Name {
+public @interface LegalEntity {
 
     String message() default "";
 

--- a/src/main/java/ru/cobp/backend/validation/constraints/Logo.java
+++ b/src/main/java/ru/cobp/backend/validation/constraints/Logo.java
@@ -1,0 +1,29 @@
+package ru.cobp.backend.validation.constraints;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import ru.cobp.backend.common.Constants;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NotBlank(message = "{logo.blank.invalid}")
+@Size(max = Constants.LOGO_MAX_LENGTH, message = "{logo.length.invalid}")
+@Pattern(regexp = Constants.LOGO_REGEXP, message = "{logo.content.invalid}")
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {})
+public @interface Logo {
+
+    String message() default "";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -19,8 +19,8 @@ CREATE TABLE banks (
 );
 
 CREATE TABLE currencies (
-	num         BIGINT      NOT NULL,
-	code        CHAR(3)     NOT NULL,
+	num         VARCHAR(3)  NOT NULL,
+	code        VARCHAR(3)  NOT NULL,
 	currency    VARCHAR(30)	NOT NULL,
 
 	CONSTRAINT pk_currencies PRIMARY KEY (num),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -19,8 +19,8 @@ CREATE TABLE banks (
 );
 
 CREATE TABLE currencies (
-	num         VARCHAR(3)  NOT NULL,
-	code        VARCHAR(3)  NOT NULL,
+	num         CHAR(3)     NOT NULL,
+	code        CHAR(3)     NOT NULL,
 	currency    VARCHAR(30)	NOT NULL,
 
 	CONSTRAINT pk_currencies PRIMARY KEY (num),

--- a/src/main/resources/validation-messages_ru.properties
+++ b/src/main/resources/validation-messages_ru.properties
@@ -1,24 +1,52 @@
 bic.blank.invalid=БИК не может быть пустым
 bic.length.invalid=БИК должен состоять из 9 символов
 bic.digits.invalid=Принимаемые символы от 0 до 9
+
 amount.positive.invalid=Сумма должна быть больше 0
 amount.min.invalid=Сумма должна быть от 10_000 до 100_000_000 включительно
 amount.max.invalid=Сумма должна быть от 10_000 до 100_000_000 включительно
+
 term.positive.invalid=Срок должен быть больше 0
 term.min.invalid=Срок должен быть от 1 до 120 месяцев включительно
 term.max.invalid=Срок должен быть от 1 до 120 месяцев включительно
+
 rate.positive.invalid=Ставка должна быть больше 0
 rate.max.invalid=Максимальная ставка должна быть менее 99.99
 rate.fraction.invalid=Дробная часть ставки должна быть две цифры после запятой
+
 page.index.invalid=Индекс страницы должен быть больше или равен 0
 page.size.invalid=Размер страницы должен быть больше 0
+
 id.positive.invalid=Идентификатор должен быть больше 0
+
 name.blank.invalid=Название не может быть пустым
 name.content.invalid=Название может содержать только символьно-числовые значения
 name.length.invalid=Максимальная длина названия должна быть не более 100 символов
+
 url.blank.invalid=Урл не может быть пустым
 url.length.invalid=Урл не может быть более 100 символов
 url.content.invalid=Урл некорректен
+
 currency-num.blank.invalid=Необходимо указать цифровой код валюты
 currency-num.length.invalid=Номер валюты должен состоять из 3 символов
 currency-num.content.invalid=Цифровой код валюты состоит из цифр от 0 до 9
+
+legalEntity.blank.invalid=Необходимо указать полное юридическое лицо банка
+legalEntity.content.invalid=Юридическое лицо банка может состоять из символов русского алфавита, дефиса, кавычек
+legalEntity.length.invalid=Максимальная длина юридического лица 100 символов
+
+description.blank.invalid=Необходимо указать описание банка
+description.content.invalid=Описание банка может содержать только символьно-числовые значения
+description.length.invalid=Максимальная длина описания 1000 символов
+
+logo.blank.invalid=Необходимо указать название лого-файла
+logo.content.invalid=Название файла может содержать только латиницу, кириллицу, знаки дефис и точка
+logo.length.invalid=Максимальная длина названия 100 символов
+
+currency-code.blank.invalid=Необходимо указать буквенный код валюты
+currency-code.content.invalid=Буквенный код валюты состоит из символов латинского алфавита заглавными буквами
+currency-code.length.invalid=Буквенный код валюты должен состоять из 3 символов
+
+currency-name.blank.invalid=Необходимо указать наименование валюты
+currency-name.content.invalid=Наименование валюты содержит только русские буквы и пробелы
+currency-name.length.invalid=Максимальная длина наименования валюты 100 символов

--- a/src/test/java/ru/cobp/backend/common/TestUtils.java
+++ b/src/test/java/ru/cobp/backend/common/TestUtils.java
@@ -2,6 +2,7 @@ package ru.cobp.backend.common;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import ru.cobp.backend.dto.bank.BankCreateUpdateDto;
 import ru.cobp.backend.dto.bank.BankResponseDto;
 import ru.cobp.backend.dto.bank.BankShortResponseDto;
 import ru.cobp.backend.dto.calculator.CalculatedCreditListResponseDto;
@@ -12,6 +13,7 @@ import ru.cobp.backend.dto.credit.CreditDto;
 import ru.cobp.backend.dto.credit.CreditResponseDto;
 import ru.cobp.backend.dto.credit.CreditShortResponseDto;
 import ru.cobp.backend.dto.credit.NewCreditDto;
+import ru.cobp.backend.dto.currency.CurrencyCreateUpdateDto;
 import ru.cobp.backend.dto.currency.CurrencyResponseDto;
 import ru.cobp.backend.dto.deposit.DepositShortResponseDto;
 import ru.cobp.backend.model.bank.Bank;
@@ -120,6 +122,25 @@ public class TestUtils {
         );
     }
 
+    public static BankCreateUpdateDto buildBankCreateUpdateDto() {
+        return BankCreateUpdateDto.builder()
+                .bic("123456789")
+                .name("Название")
+                .description("Описание")
+                .legalEntity("ОАО \"Банк\"")
+                .logo("logo.svg")
+                .url("https://url.com")
+                .build();
+    }
+
+    public static CurrencyCreateUpdateDto buildCurrencyCreateUpdateDto() {
+        return CurrencyCreateUpdateDto.builder()
+                .num("124")
+                .code("CAD")
+                .currency("Канадский доллар")
+                .build();
+    }
+
     public static List<CalculatedCredit> buildGazprombankCalculatedCredits() {
         return List.of(buildGazprombankCalculatedCredit());
     }
@@ -164,7 +185,7 @@ public class TestUtils {
     }
 
     public static Currency buildRubCurrency() {
-        return new Currency(643L, "RUB", "Российский рубль");
+        return new Currency("643", "RUB", "Российский рубль");
     }
 
     public static List<Bank> buildBanks() {
@@ -193,7 +214,7 @@ public class TestUtils {
     }
 
     public static Currency buildUsdCurrency() {
-        return new Currency(840L, "USD", "Доллар США");
+        return new Currency("840", "USD", "Доллар США");
     }
 
     public static List<CurrencyRate> buildCurrencyRates() {
@@ -209,7 +230,7 @@ public class TestUtils {
                 "044525823",
                 "Газпромбанк Кредит наличными",
                 Boolean.TRUE,
-                643L,
+                "643",
                 "https://www.gazprombank.ru/personal/take_credit/consumer_credit/5004451/",
                 10000,
                 7000000,

--- a/src/test/java/ru/cobp/backend/controller/bank/BankControllerTest.java
+++ b/src/test/java/ru/cobp/backend/controller/bank/BankControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import ru.cobp.backend.client.exchange.ExchangeRatesClient;
+import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.bank.BankCreateUpdateDto;
 import ru.cobp.backend.dto.bank.BankResponseDto;
 import ru.cobp.backend.dto.bank.BankSort;
@@ -61,14 +62,7 @@ class BankControllerTest {
 
     @BeforeEach
     void init() {
-        createUpdateDto = BankCreateUpdateDto.builder()
-                .bic("123456789")
-                .name("bank name")
-                .description("description")
-                .legalEntity("legal entity")
-                .logo("logo.svg")
-                .url("https://url.com")
-                .build();
+        createUpdateDto = TestUtils.buildBankCreateUpdateDto();
     }
 
     @Test

--- a/src/test/java/ru/cobp/backend/controller/currency/CurrencyControllerTest.java
+++ b/src/test/java/ru/cobp/backend/controller/currency/CurrencyControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import ru.cobp.backend.common.TestUtils;
 import ru.cobp.backend.dto.currency.CurrencyCreateUpdateDto;
 import ru.cobp.backend.dto.currency.CurrencyResponseDto;
 import ru.cobp.backend.mapper.CurrencyRateMapper;
@@ -48,11 +49,7 @@ class CurrencyControllerTest {
 
     @BeforeEach
     void init() {
-        createUpdateDto = CurrencyCreateUpdateDto.builder()
-                .num(124L)
-                .code("CAD")
-                .currency("Канадский доллар")
-                .build();
+        createUpdateDto = TestUtils.buildCurrencyCreateUpdateDto();
     }
 
     @Test
@@ -65,7 +62,6 @@ class CurrencyControllerTest {
                 .andExpect(jsonPath("$.num").value(createUpdateDto.getNum()))
                 .andExpect(jsonPath("$.code").value(createUpdateDto.getCode()))
                 .andExpect(jsonPath("$.currency").value(createUpdateDto.getCurrency()));
-
     }
 
     @Test

--- a/src/test/java/ru/cobp/backend/dto/bank/BankDtoValidationTest.java
+++ b/src/test/java/ru/cobp/backend/dto/bank/BankDtoValidationTest.java
@@ -1,0 +1,62 @@
+package ru.cobp.backend.dto.bank;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.Validator;
+import jakarta.validation.Validation;
+import jakarta.validation.ConstraintViolation;
+import ru.cobp.backend.common.TestUtils;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BankDtoValidationTest {
+    static Validator validator;
+    static BankCreateUpdateDto createUpdateDto;
+
+    static {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.usingContext().getValidator();
+    }
+
+    @BeforeEach
+    void init() {
+        createUpdateDto = TestUtils.buildBankCreateUpdateDto();
+    }
+
+    @Test
+    void testBankCreateUpdateDto_whenValid_thenNoValidationErrors() {
+        // when
+        Set<ConstraintViolation<BankCreateUpdateDto>> violations = validator.validate(createUpdateDto);
+
+        // then
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    void testBankCreateUpdateDto_whenInvalidParameters_throwValidationExceptions() {
+        // given
+        createUpdateDto.setBic("123456A");  // BIC 6 digits & 1 letter
+        createUpdateDto.setName("XYZ");     // english letters
+        createUpdateDto.setDescription(""); // empty description
+
+        // when
+        Set<ConstraintViolation<BankCreateUpdateDto>> violations = validator.validate(createUpdateDto);
+
+        Set<String> messages = violations.stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.toSet());
+
+        // then
+        assertEquals(4, violations.size());
+        assertTrue(messages.contains("БИК должен состоять из чисел от 0 до 9"));
+        assertTrue(messages.contains("БИК должен состоять из 9 символов"));
+        assertTrue(messages.contains("Название может состоять из символов русского алфавита, дефиса"));
+        assertTrue(messages.contains("Необходимо указать описание банка"));
+    }
+
+}

--- a/src/test/java/ru/cobp/backend/dto/bank/BankDtoValidationTest.java
+++ b/src/test/java/ru/cobp/backend/dto/bank/BankDtoValidationTest.java
@@ -40,9 +40,9 @@ class BankDtoValidationTest {
     @Test
     void testBankCreateUpdateDto_whenInvalidParameters_throwValidationExceptions() {
         // given
-        createUpdateDto.setBic("123456A");  // BIC 6 digits & 1 letter
-        createUpdateDto.setName("XYZ");     // english letters
-        createUpdateDto.setDescription(""); // empty description
+        createUpdateDto.setBic("123456A");
+        createUpdateDto.setName("XYZ");
+        createUpdateDto.setDescription("");
 
         // when
         Set<ConstraintViolation<BankCreateUpdateDto>> violations = validator.validate(createUpdateDto);
@@ -53,10 +53,10 @@ class BankDtoValidationTest {
 
         // then
         assertEquals(4, violations.size());
-        assertTrue(messages.contains("БИК должен состоять из чисел от 0 до 9"));
-        assertTrue(messages.contains("БИК должен состоять из 9 символов"));
-        assertTrue(messages.contains("Название может состоять из символов русского алфавита, дефиса"));
-        assertTrue(messages.contains("Необходимо указать описание банка"));
+        assertTrue(messages.contains("{bic.length.invalid}"));
+        assertTrue(messages.contains("{name.content.invalid}"));
+        assertTrue(messages.contains("{bic.digits.invalid}"));
+        assertTrue(messages.contains("{description.blank.invalid}"));
     }
 
 }

--- a/src/test/java/ru/cobp/backend/dto/currency/CurrencyDtoValidationTest.java
+++ b/src/test/java/ru/cobp/backend/dto/currency/CurrencyDtoValidationTest.java
@@ -1,0 +1,59 @@
+package ru.cobp.backend.dto.currency;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ru.cobp.backend.common.TestUtils;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CurrencyDtoValidationTest {
+    static Validator validator;
+    static CurrencyCreateUpdateDto createUpdateDto;
+
+    static {
+        ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.usingContext().getValidator();
+    }
+
+    @BeforeEach
+    void init() {
+        createUpdateDto = TestUtils.buildCurrencyCreateUpdateDto();
+    }
+
+    @Test
+    void testBankCreateUpdateDto_whenValid_thenNoValidationErrors() {
+        // when
+        Set<ConstraintViolation<CurrencyCreateUpdateDto>> violations = validator.validate(createUpdateDto);
+
+        // then
+        assertEquals(0, violations.size());
+    }
+
+    @Test
+    void testBankCreateUpdateDto_whenInvalidParameters_throwValidationExceptions() {
+        // given
+        createUpdateDto.setCode("X_30");
+        createUpdateDto.setCurrency("Canadian dollar");
+
+        // when
+        Set<ConstraintViolation<CurrencyCreateUpdateDto>> violations = validator.validate(createUpdateDto);
+
+        Set<String> messages = violations.stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.toSet());
+
+        // then
+        assertEquals(3, violations.size());
+        assertTrue(messages.contains("Наименование валюты содержит только русские буквы и пробелы"));
+        assertTrue(messages.contains("Буквенный код валюты состоит из символов латинского алфавита"));
+        assertTrue(messages.contains("Буквенный код валюты должен состоять из 3 символов"));
+    }
+
+}

--- a/src/test/java/ru/cobp/backend/dto/currency/CurrencyDtoValidationTest.java
+++ b/src/test/java/ru/cobp/backend/dto/currency/CurrencyDtoValidationTest.java
@@ -51,9 +51,9 @@ class CurrencyDtoValidationTest {
 
         // then
         assertEquals(3, violations.size());
-        assertTrue(messages.contains("Наименование валюты содержит только русские буквы и пробелы"));
-        assertTrue(messages.contains("Буквенный код валюты состоит из символов латинского алфавита"));
-        assertTrue(messages.contains("Буквенный код валюты должен состоять из 3 символов"));
+        assertTrue(messages.contains("{currency-name.content.invalid}"));
+        assertTrue(messages.contains("{currency-code.content.invalid}"));
+        assertTrue(messages.contains("{currency-code.length.invalid}"));
     }
 
 }

--- a/src/test/java/ru/cobp/backend/service/credit/CreditServiceTest.java
+++ b/src/test/java/ru/cobp/backend/service/credit/CreditServiceTest.java
@@ -100,7 +100,7 @@ public class CreditServiceTest {
         Credit expectedCredit = TestUtils.buildGazprombankCredit();
 
         when(bankService.getBankByBicOrThrowException(newCreditDto.getBankBic())).thenReturn(bank);
-        when(currencyService.getById(newCreditDto.getCurrencyNum())).thenReturn(currency);
+        when(currencyService.getByNum(newCreditDto.getCurrencyNum())).thenReturn(currency);
         when(creditMapper.toCredit(newCreditDto)).thenReturn(creditWithoutBankAndCurrency);
         when(creditRepository.save(any(Credit.class))).thenReturn(expectedCredit);
 


### PR DESCRIPTION
Добавлены:
- валидаторы для банков и валют для BankCreateUpdateDto и CurrencyCreateUpdateDto
- обработчик ошибок валидации со статусом 400
- тесты по валидации 

Вопросы:
1. Валидацию параметров путей (bic и num) для /post и /delete не делал пока – мне кажется проще это отдать на реализацию фронтам, у себя на бэке ожидать уже корректные данные, и возвращать 404 если не найдено. Кто что думает по этому поводу? 
2. У нас пока обновление идет через /put – имхо это неправильно, поскольку предполагаем, что объект полностью обновлять будем.  
    * Предложение 1: не хотим перейти в update запросах на /patch? 
    * Предложение 2: сделать для UpdateDtos поля необязательными параметрами, иначе странно с точки зрения бизнес логики ожидать полную замену от клиента каждый раз.